### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Peder
 maintainer=Peder <peder.nordenstrom@fatshark.se>
 sentence=Simple rotary encoder
 paragraph=Simple rotary encoder
-category=Buttons
+category=Signal Input/Output
 url=
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Buttons' in library PDR Rotary Encoder is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format